### PR TITLE
fix repo url for manual installation up to date with master

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The preferred method of installation is [Package Control](https://packagecontrol
 
 Close Sublime Text then download or clone this repository to a directory named `phpunitkit` in the Sublime Text Packages directory for your platform:
 
-* Linux: `git clone https://github.com/gerardroche/sublime-phpunitkit.git ~/.config/sublime-text-3/Packages/phpunitkit`
-* OSX: `git clone https://github.com/gerardroche/sublime-phpunitkit.git ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/phpunitkit`
-* Windows: `git clone https://github.com/gerardroche/sublime-phpunitkit.git %APPDATA%\Sublime/ Text/ 3/Packages/phpunitkit`
+* Linux: `git clone https://github.com/carlevison/sublime-phpunit.git ~/.config/sublime-text-3/Packages/phpunitkit`
+* OSX: `git clone https://github.com/carlevison/sublime-phpunit.git ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/phpunitkit`
+* Windows: `git clone https://github.com/carlevison/sublime-phpunit.git %APPDATA%\Sublime/ Text/ 3/Packages/phpunitkit`
 
 ## COMMANDS
 


### PR DESCRIPTION
Fixed the README repo url for manual installation this time being up-to-date with the master branch.