### PR TITLE
Support running iTerm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes are documented in this file using the [Keep a CHANGELOG](htt
 
 ## 3.2.0 - Unreleased
 
+* Added: [#86](https://github.com/gerardroche/sublime-phpunit/issues/86): Support running tests in iTerm
 * Added: [#81](https://github.com/gerardroche/sublime-phpunit/issues/81): Command to run a full test suite
 
 ## [3.1.1] - 2019-02-05

--- a/bin/osx_iterm
+++ b/bin/osx_iterm
@@ -1,0 +1,18 @@
+#!/usr/bin/osascript
+
+on run argv
+  tell application "iTerm2"
+    activate
+    set _window to (current window)
+    if _window is equal to missing value then
+      create window with default profile
+    end if
+    tell current window
+      tell current session
+        repeat with arg in argv
+          write text arg
+        end repeat
+      end tell
+    end tell
+  end tell
+end run

--- a/plugin.py
+++ b/plugin.py
@@ -564,35 +564,49 @@ class PHPUnit():
                 if view.is_dirty() and view.file_name():
                     view.run_command('save')
 
-        self.window.run_command('exec', {
-            'env': env,
-            'cmd': cmd,
-            'file_regex': exec_file_regex(),
-            'quiet': not is_debug(self.view),
-            'shell': False,
-            'syntax': 'Packages/{}/res/text-ui-result.sublime-syntax'.format(__name__.split('.')[0]),
-            'word_wrap': False,
-            'working_dir': working_dir
-        })
-
         set_window_setting('phpunit._test_last', {
             'working_dir': working_dir,
             'file': file,
             'options': options
         }, window=self.window)
 
-        panel = self.window.create_output_panel('exec')
-        panel_settings = panel.settings()
-        panel_settings.set('rulers', [])
+        if self.view.settings().get('phpunit.strategy') == 'iterm':
+            osx_iterm_script = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), 'bin', 'osx_iterm')
 
-        if self.view.settings().has('phpunit.text_ui_result_font_size'):
-            panel_settings.set(
-                'font_size',
-                self.view.settings().get('phpunit.text_ui_result_font_size')
-            )
+            cmd = [osx_iterm_script] + cmd
 
-        color_scheme = self.get_auto_generated_color_scheme()
-        panel_settings.set('color_scheme', color_scheme)
+            self.window.run_command('exec', {
+                'env': env,
+                'cmd': cmd,
+                'quiet': not is_debug(self.view),
+                'shell': False,
+                'working_dir': working_dir
+            })
+        else:
+            self.window.run_command('exec', {
+                'env': env,
+                'cmd': cmd,
+                'file_regex': exec_file_regex(),
+                'quiet': not is_debug(self.view),
+                'shell': False,
+                'syntax': 'Packages/{}/res/text-ui-result.sublime-syntax'.format(__name__.split('.')[0]),
+                'word_wrap': False,
+                'working_dir': working_dir
+            })
+
+            panel = self.window.create_output_panel('exec')
+            panel_settings = panel.settings()
+            panel_settings.set('rulers', [])
+
+            if self.view.settings().has('phpunit.text_ui_result_font_size'):
+                panel_settings.set(
+                    'font_size',
+                    self.view.settings().get('phpunit.text_ui_result_font_size')
+                )
+
+            color_scheme = self.get_auto_generated_color_scheme()
+            panel_settings.set('color_scheme', color_scheme)
 
     def run_last(self):
         last_test_args = get_window_setting('phpunit._test_last', window=self.window)


### PR DESCRIPTION
**WIP**

To run tests in iTerm, set the **strategy** to "iterm":

 **Menu > Preferences > Settings**

```
"phpunit.strategy": "iterm",
```

## Notes

I've added `.no-sublime-package` to unpack the package on install, because we now have an iterm executable to run the tests in the iterm strategy,

> If including executables or shared libraries, add a .no-sublime-package file. Adding this file to the root of your repository will prevent Package Control from keeping your package packed as a .sublime-package file in ST3.  https://packagecontrol.io/docs/submitting_a_package


Close #86 

See README for details.