### PR TITLE
Add replace phpunit command option

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -45,4 +45,11 @@
 
     // Prepends given command to the test command.
     "phpunit.prepend_cmd": [],
+
+    // Replaces phpunit command with your custom command(in value) if
+    // specified file(in key) exists in current working directory.
+    // $WORK_DIR in commands will be replaced with current working directory.
+    "phpunit.replace_phpunit_cmd_if_key_exists": {
+        "artisan": ["$WORK_DIR/artisan", "test"]
+    }
 }

--- a/plugin.py
+++ b/plugin.py
@@ -805,12 +805,9 @@ class PHPUnit():
         composer = self.view.settings().get('phpunit.composer')
         debug_message('phpunit.composer: %s', composer)
 
-        custom_commands = self.view.settings().get('phpunit.replace_phpunit_cmd_if_key_exists')
+        phpunit_replacement_cmd = self.get_phpunit_replacement_cmd(working_dir)
 
-        for k, v in custom_commands.items():
-            if not os.path.exists(k):
-                continue
-            return [cmd.replace('$WORK_DIR', working_dir) for cmd in v]
+        if phpunit_replacement_cmd: return phpunit_replacement_cmd
 
         executable = self.view.settings().get('phpunit.executable')
         if executable:
@@ -819,6 +816,16 @@ class PHPUnit():
             return [executable]
 
         return [_get_phpunit_executable(working_dir, composer)]
+
+    def get_phpunit_replacement_cmd(self, working_dir):
+        custom_commands = self.view.settings().get('phpunit.replace_phpunit_cmd_if_key_exists')
+
+        for k, v in custom_commands.items():
+            if not os.path.exists(k):
+                continue
+            return [cmd.replace('$WORK_DIR', working_dir) for cmd in v]
+
+        return False
 
     def get_auto_generated_color_scheme(self):
         """Try to patch color scheme with default test result colors."""

--- a/plugin.py
+++ b/plugin.py
@@ -575,8 +575,7 @@ class PHPUnit():
 
             options = self.filter_options(options)
 
-            cmd = []
-            cmd.append(phpunit_executable)
+            cmd = phpunit_executable
             cmd = build_cmd_options(options, cmd)
 
             if file:
@@ -806,13 +805,20 @@ class PHPUnit():
         composer = self.view.settings().get('phpunit.composer')
         debug_message('phpunit.composer: %s', composer)
 
+        custom_commands = self.view.settings().get('phpunit.replace_phpunit_cmd_if_key_exists')
+
+        for k, v in custom_commands.items():
+            if not os.path.exists(k):
+                continue
+            return [cmd.replace('$WORK_DIR', working_dir) for cmd in v]
+
         executable = self.view.settings().get('phpunit.executable')
         if executable:
             executable = filter_path(executable)
             debug_message('phpunit.executable: %s', executable)
-            return executable
+            return [executable]
 
-        return _get_phpunit_executable(working_dir, composer)
+        return [_get_phpunit_executable(working_dir, composer)]
 
     def get_auto_generated_color_scheme(self):
         """Try to patch color scheme with default test result colors."""


### PR DESCRIPTION
Add `phpunit.replace_phpunit_cmd_if_key_exists` option, to run `$WORK_DIR/artisan, test`, or running tests from project script.

But there are two issues:
- On first run it will run phpunit command itself
- When running tests on sublime panel, there is no color:

![Screenshot from 2023-04-09 13-26-04](https://user-images.githubusercontent.com/68776630/230766412-1854e393-43c8-46bf-91cb-46429c6de609.png)
